### PR TITLE
Wo

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -6,86 +6,156 @@
 #include <algorithm>
 #include "ticktock.h"
 
+#include <tbb/tbb.h>
+#include "pod.h"
+
 // TODO: 并行化所有这些 for 循环
 
 template <class T, class Func>
-std::vector<T> fill(std::vector<T> &arr, Func const &func) {
+std::vector<T> fill(std::vector<T> &arr, Func const &func)
+{
     TICK(fill);
-    for (size_t i = 0; i < arr.size(); i++) {
-        arr[i] = func(i);
-    }
+    size_t n = arr.size();
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, n), 
+        [&](const tbb::blocked_range<size_t> &r)
+        {
+            for(size_t i = r.begin(); i < r.end(); i++)
+                arr[i] = func(i);
+        }
+    );
     TOCK(fill);
     return arr;
 }
 
 template <class T>
-void saxpy(T a, std::vector<T> &x, std::vector<T> const &y) {
+void saxpy(T a, std::vector<T> &x, std::vector<T> const &y)
+{
     TICK(saxpy);
-    for (size_t i = 0; i < x.size(); i++) {
-       x[i] = a * x[i] + y[i];
-    }
+    size_t n = x.size();
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, n),
+        [&](const tbb::blocked_range<size_t> &r)
+        {
+            for(size_t i = r.begin(); i < r.end(); i++)
+                x[i] = a * x[i] + y[i];
+        }
+    );
     TOCK(saxpy);
 }
 
 template <class T>
-T sqrtdot(std::vector<T> const &x, std::vector<T> const &y) {
+T sqrtdot(std::vector<T> const &x, std::vector<T> const &y)
+{
     TICK(sqrtdot);
-    T ret = 0;
-    for (size_t i = 0; i < std::min(x.size(), y.size()); i++) {
-        ret += x[i] * y[i];
-    }
+    size_t n = x.size();
+    T ret = tbb::parallel_reduce(
+        tbb::blocked_range<size_t>(0, n), (T)0,
+        [&](const tbb::blocked_range<size_t> &r, T ans)
+        {
+            for(size_t i = r.begin(); i < r.end(); i++)
+                ans += x[i] * y[i];
+            return ans;
+        },
+        [](T a, T b)
+        {
+            return a + b;
+        }
+    );
     ret = std::sqrt(ret);
     TOCK(sqrtdot);
     return ret;
 }
 
 template <class T>
-T minvalue(std::vector<T> const &x) {
+T minvalue(std::vector<T> const &x)
+{
     TICK(minvalue);
-    T ret = x[0];
-    for (size_t i = 1; i < x.size(); i++) {
-        if (x[i] < ret)
-            ret = x[i];
-    }
+    size_t n = x.size();
+    T ret = tbb::parallel_reduce(
+        tbb::blocked_range<size_t>(0, n), (T)x[0],
+        [&](const tbb::blocked_range<size_t> &r, T ans)
+        {
+            for(size_t i = r.begin(); i < r.end(); i++)
+                ans = std::min(ans, x[i]);
+            return ans;
+        },
+        [](T a, T b)
+        {
+            return std::min(a, b);
+        }
+    );
     TOCK(minvalue);
     return ret;
 }
 
 template <class T>
-std::vector<T> magicfilter(std::vector<T> const &x, std::vector<T> const &y) {
+auto magicfilter(std::vector<T> const &x, std::vector<T> const &y)
+{
     TICK(magicfilter);
-    std::vector<T> res;
-    for (size_t i = 0; i < std::min(x.size(), y.size()); i++) {
-        if (x[i] > y[i]) {
-            res.push_back(x[i]);
-        } else if (y[i] > x[i] && y[i] > 0.5f) {
-            res.push_back(y[i]);
-            res.push_back(x[i] * y[i]);
-        }
-    }
+    tbb::concurrent_vector<pod<T> > res;
+    size_t n = x.size();
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, n),
+        [&](const tbb::blocked_range<size_t> &r)
+        {
+            std::vector<pod<T> > ans;
+            ans.reserve(r.size());
+            for(size_t i = r.begin(); i < r.end(); i++)
+            {
+                if(x[i] > y[i])
+                    ans.push_back(x[i]);
+                else if(y[i] > x[i] && y[i] > 0.5f)
+                {
+                    ans.push_back(y[i]);
+                    ans.push_back(x[i] * y[i]);
+                }
+            }
+            auto it = res.grow_by(ans.size());
+            std::copy(ans.begin(), ans.end(), it);
+        },
+        tbb::static_partitioner{}
+    );
     TOCK(magicfilter);
     return res;
 }
 
 template <class T>
-T scanner(std::vector<T> &x) {
+T scanner(std::vector<T> &x)
+{
     TICK(scanner);
-    T ret = 0;
-    for (size_t i = 0; i < x.size(); i++) {
-        ret += x[i];
-        x[i] = ret;
-    }
+    size_t n = x.size();
+    T ret = tbb::parallel_scan(
+        tbb::blocked_range<size_t>(0, n), (T)0,
+        [&](const tbb::blocked_range<size_t> &r, float ans, auto is_final)
+        {
+            for(size_t i = r.begin(); i < r.end(); i++)
+            {
+                ans += x[i];
+                if(is_final)
+                    x[i] = ans;
+            }
+            return ans;
+        },
+        [](T a, T b)
+        {
+            return a + b;
+        }
+    );
     TOCK(scanner);
     return ret;
 }
 
-int main() {
-    size_t n = 1<<26;
+int main()
+{
+    size_t n = 1 << 26;
     std::vector<float> x(n);
     std::vector<float> y(n);
 
-    fill(x, [&] (size_t i) { return std::sin(i); });
-    fill(y, [&] (size_t i) { return std::cos(i); });
+    fill(x, [&](size_t i)
+         { return std::sin(i); });
+    fill(y, [&](size_t i)
+         { return std::cos(i); });
 
     saxpy(0.5f, x, y);
 


### PR DESCRIPTION
使用 `tbb::task_arena ta(4)` 调整环境为4线程。
|  | 串行耗时 | 并行耗时 | 加速比 |
|--|-----------|-----------|---------|
| fill | 0.44 | 0.13 | 3.38 |
| saxpy | 0.029 | 0.024 | 1.28 |
| sqrtdot | 0.061 | 0.020 | 3.05 |
| minvalue | 0.060 | 0.010 | 6 |
| magicfilter | 0.15 | 0.093 | 1.61 |
| scanner | 0.059 | 0.044 | 1.34 |

1. `fill` 和 `saxpy` 都使用 `parallel_for` 并行，加速比差好多？
2. `sqrtdot` 和 `minvalue` 都使用 ` parallel_reduce` 并行
3. `magicfilter` 使用`parallel_for`并行
用提供的`pod.h` 不进行初始化，但是前后差别并不大
4. `scanner` 使用 `parallel_scan` 并行
