### PR TITLE
done

### DIFF
--- a/after.txt
+++ b/after.txt
@@ -1,0 +1,11 @@
+fill: 0.130924s
+fill: 0.132913s
+saxpy: 0.0101733s
+sqrtdot: 0.0241576s
+5792.62
+minvalue: 0.0222686s
+-1.11803
+magicfilter: 0.115075s
+55924034
+scanner: 0.0292774s
+0

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_reduce.h>
 #include <tbb/parallel_scan.h>
+#include "pod.h"
 
 // TODO: 并行化所有这些 for 循环
 
@@ -88,9 +89,9 @@ T minvalue(std::vector<T> const &x) {
 }
 
 template <class T>
-std::vector<T> magicfilter(std::vector<T> const &x, std::vector<T> const &y) {
+auto magicfilter(std::vector<T> const &x, std::vector<T> const &y) {
     TICK(magicfilter);
-    std::vector<T> res;
+    std::vector<pod<T>> res;
 
     std::atomic<size_t> a_size=0;
     size_t n = std::min(x.size(), y.size());
@@ -100,7 +101,7 @@ std::vector<T> magicfilter(std::vector<T> const &x, std::vector<T> const &y) {
     ta.execute([&]{
         tbb::parallel_for(tbb::blocked_range<size_t>(0,n),
               [&](tbb::blocked_range<size_t> r){
-                  std::vector<T> la(r.size());
+                  std::vector<pod<T>> la(r.size());
                   size_t la_idx=0;
                   for (size_t i = r.begin(); i < r.end(); i++) {
                       if (x[i] > y[i]) {

--- a/main.cpp
+++ b/main.cpp
@@ -5,15 +5,24 @@
 #include <numeric>
 #include <algorithm>
 #include "ticktock.h"
+#include <tbb/parallel_for.h>
+#include <tbb/parallel_reduce.h>
+#include <tbb/parallel_scan.h>
 
 // TODO: 并行化所有这些 for 循环
 
 template <class T, class Func>
 std::vector<T> fill(std::vector<T> &arr, Func const &func) {
     TICK(fill);
-    for (size_t i = 0; i < arr.size(); i++) {
-        arr[i] = func(i);
-    }
+    tbb::task_arena ta(8);
+    ta.execute([&]{
+        tbb::parallel_for(tbb::blocked_range<size_t>(0,arr.size()),[&](tbb::blocked_range<size_t> r){
+            for (size_t i = r.begin(); i !=r.end(); i++) {
+                arr[i] = func(i);
+            }
+        });
+    });
+
     TOCK(fill);
     return arr;
 }
@@ -21,9 +30,15 @@ std::vector<T> fill(std::vector<T> &arr, Func const &func) {
 template <class T>
 void saxpy(T a, std::vector<T> &x, std::vector<T> const &y) {
     TICK(saxpy);
-    for (size_t i = 0; i < x.size(); i++) {
-       x[i] = a * x[i] + y[i];
-    }
+    tbb::task_arena ta(8);
+    ta.execute([&]{
+        tbb::parallel_for(tbb::blocked_range<size_t>(0,x.size()),[&](tbb::blocked_range<size_t> r){
+            for (size_t i = r.begin(); i !=r.end(); i++) {
+                x[i] = a * x[i] + y[i];
+            }
+        });
+    });
+
     TOCK(saxpy);
 }
 
@@ -31,9 +46,19 @@ template <class T>
 T sqrtdot(std::vector<T> const &x, std::vector<T> const &y) {
     TICK(sqrtdot);
     T ret = 0;
-    for (size_t i = 0; i < std::min(x.size(), y.size()); i++) {
-        ret += x[i] * y[i];
-    }
+    tbb::task_arena ta(8);
+    ta.execute([&]{
+        ret=tbb::parallel_reduce(tbb::blocked_range<size_t>(0,std::min(x.size(), y.size())),(T )0,
+             [&](tbb::blocked_range<size_t> r, T local_res){
+                 for (size_t i = r.begin(); i != r.end(); i++) {
+                     local_res += x[i] * y[i];
+                 }
+                 return local_res;
+             },
+             [](T x,T y){
+                 return x+y;
+             });
+    });
     ret = std::sqrt(ret);
     TOCK(sqrtdot);
     return ret;
@@ -43,10 +68,21 @@ template <class T>
 T minvalue(std::vector<T> const &x) {
     TICK(minvalue);
     T ret = x[0];
-    for (size_t i = 1; i < x.size(); i++) {
-        if (x[i] < ret)
-            ret = x[i];
-    }
+    tbb::task_arena ta(8);
+    ta.execute([&]{
+        ret=tbb::parallel_reduce(tbb::blocked_range<size_t>(0, x.size()),x[0],
+             [&](tbb::blocked_range<size_t> r, T local_res){
+                 for (size_t i = r.begin()+1; i != r.end(); i++) {
+                     if (x[i] < local_res)
+                         local_res = x[i];
+                 }
+                 return local_res;
+             },
+             [](T x,T y){
+                 return std::min(x,y);
+             });
+    });
+
     TOCK(minvalue);
     return ret;
 }
@@ -55,14 +91,34 @@ template <class T>
 std::vector<T> magicfilter(std::vector<T> const &x, std::vector<T> const &y) {
     TICK(magicfilter);
     std::vector<T> res;
-    for (size_t i = 0; i < std::min(x.size(), y.size()); i++) {
-        if (x[i] > y[i]) {
-            res.push_back(x[i]);
-        } else if (y[i] > x[i] && y[i] > 0.5f) {
-            res.push_back(y[i]);
-            res.push_back(x[i] * y[i]);
-        }
-    }
+
+    std::atomic<size_t> a_size=0;
+    size_t n = std::min(x.size(), y.size());
+    res.resize(n);
+
+    tbb::task_arena ta(8);
+    ta.execute([&]{
+        tbb::parallel_for(tbb::blocked_range<size_t>(0,n),
+              [&](tbb::blocked_range<size_t> r){
+                  std::vector<T> la(r.size());
+                  size_t la_idx=0;
+                  for (size_t i = r.begin(); i < r.end(); i++) {
+                      if (x[i] > y[i]) {
+                          la[la_idx++]=x[i];
+                      } else if (y[i] > x[i] && y[i] > 0.5f) {
+                          la[la_idx++]=y[i];
+                          la[la_idx++]=x[i] * y[i];
+                      }
+                  }
+
+                  size_t base=a_size.fetch_add(la_idx);
+                  for (size_t i = 0; i < la_idx; ++i) {
+                      res[base+i]=la[i];
+                  }
+              });
+    });
+
+    res.resize(a_size);
     TOCK(magicfilter);
     return res;
 }
@@ -70,11 +126,31 @@ std::vector<T> magicfilter(std::vector<T> const &x, std::vector<T> const &y) {
 template <class T>
 T scanner(std::vector<T> &x) {
     TICK(scanner);
-    T ret = 0;
-    for (size_t i = 0; i < x.size(); i++) {
-        ret += x[i];
-        x[i] = ret;
-    }
+    T ret=0;
+    tbb::task_arena ta(8);
+    ta.execute([&]{
+        ret = tbb::parallel_scan(tbb::blocked_range<size_t>(0,x.size()),(T)0,
+           [&](tbb::blocked_range<size_t> r,T local_res,auto is_final){
+               for (size_t i = r.begin(); i < r.end(); i++) {
+                   local_res += x[i];
+                   if(is_final){
+                       x[i] = ret;
+                   }
+               }
+
+               return local_res;
+           },
+           [](T x,T y){
+               return x+y;
+           });
+    });
+
+
+//    T ret=0;
+//    for (size_t i = 0; i < x.size(); i++) {
+//        ret += x[i];
+//        x[i] = ret;
+//    }
     TOCK(scanner);
     return ret;
 }


### PR DESCRIPTION
代码中使用了最大8线程的任务组。
优化前：
fill: 0.840091s
fill: 0.761348s
saxpy: 0.0335867s
sqrtdot: 0.0801362s
5165.4
minvalue: 0.124584s
-1.11803
magicfilter: 0.21705s
55924034
scanner: 0.0785354s
6.18926e+07
优化后：
fill: 0.130924s，6.416倍
fill: 0.132913s，5.728倍
saxpy: 0.0101733s，3.325倍
sqrtdot: 0.0241576s，3.317倍
5792.62
minvalue: 0.0222686s，5.596倍
-1.11803
magicfilter: 0.0409125s，5.305倍
55924034
scanner: 0.0292774s，2.689倍
0

- 使用parallel for加速的fill、saxpy，对fill加速效果良好，saxpy不佳，因为后者计算量不够大；
- 用parallel reduce对sqrtdot、minvalue加速
- 直接对scanner用parallel scan加速
- magicfilter：采用无锁加速，并且用pod包装。

